### PR TITLE
LibCompat-1.0: move tContains from global namespace to lib

### DIFF
--- a/Skada/Core/Menus.lua
+++ b/Skada/Core/Menus.lua
@@ -727,7 +727,7 @@ do
 				local mode = modes[i]
 				categorized[mode.category] = categorized[mode.category] or {}
 				categorized[mode.category][#categorized[mode.category] + 1] = mode
-				if not tContains(categories, mode.category) then
+				if not Skada.tContains(categories, mode.category) then
 					categories[#categories + 1] = mode.category
 				end
 			end

--- a/Skada/Libs/LibCompat-1.0/LibCompat-1.0.lua
+++ b/Skada/Libs/LibCompat-1.0/LibCompat-1.0.lua
@@ -98,7 +98,7 @@ do
 	end
 
 	-- replace the global function
-	_G.tContains = function(tbl, item)
+	local function tContains(tbl, item)
 		for _, v in pairs(tbl) do
 			if item == v then
 				return true
@@ -109,6 +109,7 @@ do
 
 	lib.tLength = tLength
 	lib.tCopy = tCopy
+	lib.tContains = tContains
 end
 
 -------------------------------------------------------------------------------

--- a/Skada/Modules/Enemies.lua
+++ b/Skada/Modules/Enemies.lua
@@ -25,7 +25,7 @@ Skada:RegisterModule("Enemy Damage Taken", function(L, P, _, C, new, del, clear)
 	local UnitHealthInfo, UnitPowerInfo = Skada.UnitHealthInfo, Skada.UnitPowerInfo
 	local UnitExists, UnitGUID = UnitExists, UnitGUID
 	local UnitHealthMax, UnitPowerMax = UnitHealthMax, UnitPowerMax
-	local tContains = tContains
+	local tContains = Skada.tContains
 
 	-- this table holds the units to which the damage done is
 	-- collected into a new fake unit.

--- a/Skada/Modules/Failbot.lua
+++ b/Skada/Modules/Failbot.lua
@@ -10,7 +10,7 @@ Skada:RegisterModule("Fails", function(L, P)
 	local spellmod = mod:NewModule("Event's failed players")
 	local ignoredSpells = Skada.dummyTable -- Edit Skada\Core\Tables.lua
 
-	local pairs, tostring, format, tContains = pairs, tostring, string.format, tContains
+	local pairs, tostring, format, tContains = pairs, tostring, string.format, Skada.tContains
 	local GetSpellInfo, UnitGUID, IsInGroup = Skada.GetSpellInfo or GetSpellInfo, UnitGUID, Skada.IsInGroup
 	local _
 


### PR DESCRIPTION
Overwrite of `tContains` can cause unexpected behavior in Addons that depend on its old behavior and expect exactly `1` or `nil` as return and iterate the table as an array.
In addition, some custom servers change the interface code and use this function in protected code areas, and that overwrite will cause taint errors.

```
Global variable tContains tainted by Skada - Interface\AddOns\Skada\Libs\LibCompat-1.0\LibCompat-1.0.lua:108
Execution tainted by Skada while reading tContains - Interface\FrameXML\SpellBookFrame.lua:1477 SpellButton_UpdateBorderOverlay()
    Interface\FrameXML\SpellBookFrame.lua:1515 SpellButton_OnShow()
    SpellButton12:OnShow()
    SpellBookSpellIconsFrame:Show()
    Interface\FrameXML\SpellBookFrame.lua:1295 SpellBookFrame_Update()
    Interface\FrameXML\SpellBookFrame.lua:350
    UpdateSpells()
    Interface\FrameXML\SpellBookFrame.lua:292 ToggleSpellBook()
    Interface\FrameXML\SpellBookFrame.lua:1964 SpellBookFrameTabButton_OnClick()
    SpellBookFrameTabButton1:OnClick()
An action was blocked in combat because of taint from Skada - SpellButton1:SetAttribute()
    Interface\FrameXML\SpellBookFrame.lua:1714 SpellButton_UpdateButton()
    Interface\FrameXML\SpellBookFrame.lua:1510 SpellButton_OnShow()
    SpellButton1:OnShow()
    SpellBookFrame:Show()
    Interface\FrameXML\UIParent.lua:1657 <unnamed>:SetUIPanel()
    Interface\FrameXML\UIParent.lua:1501 <unnamed>:ShowUIPanel()
    Interface\FrameXML\UIParent.lua:1388
    <unnamed>:SetAttribute()
    Interface\FrameXML\UIParent.lua:2073
    securecall()
    Interface\FrameXML\SpellBookFrame.lua:295 ToggleSpellBook()
    TOGGLESPELLBOOK:1
```